### PR TITLE
Use a long running worker threads instead of std::async

### DIFF
--- a/src/WorkerThread.hpp
+++ b/src/WorkerThread.hpp
@@ -1,0 +1,73 @@
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <queue>
+#include <future>
+
+template<typename R, typename... Args>
+class WorkerThread {
+private:
+    struct item {
+        std::packaged_task<R()> work;
+        enum control_t { process, stop } control;
+
+        item(std::packaged_task<R()> &&c) : work(std::move(c)), control(process) {}
+        item(control_t c) : work(), control(c) {}
+    };
+
+    template<typename V>
+    class async_queue {
+    private:
+        std::queue<V> list;
+        std::mutex mutex;
+        std::condition_variable cv;
+
+    public:
+        void push(V&& i) {
+            std::unique_lock<std::mutex> lock(mutex, std::defer_lock);
+            std::lock_guard<std::unique_lock<std::mutex>> guard(lock);
+            list.push(std::forward<V>(i));
+            cv.notify_one();
+        }
+
+        V pop() {
+            std::unique_lock<std::mutex> lock(mutex, std::defer_lock);
+            std::lock_guard<std::unique_lock<std::mutex>> guard(lock);
+            while (list.empty())
+                cv.wait(lock);
+            V tmp = std::move(list.front());
+            list.pop();
+            return std::move(tmp);
+        }
+    };
+
+    async_queue<item> queue;
+    std::thread thread;
+
+    void loop() {
+        while (true) {
+            item next = queue.pop();
+
+            if (next.control == item::stop)
+                return;
+
+            next.work();
+        }
+    }
+
+public:
+    WorkerThread() : thread(std::mem_fn(&WorkerThread::loop), this) {}
+
+    ~WorkerThread() {
+        queue.push(item(item::stop));
+        thread.join();
+    }
+
+    std::future<R> push(R (*fn) (Args...), Args... args) {
+        item it(std::packaged_task<R()>(std::bind(fn, std::forward<Args>(args)...)));
+        std::future<R> fut = it.work.get_future();
+
+        queue.push(std::move(it));
+        return std::move(fut);
+    }
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "MainDialog.hpp"
 #include "RieszTransform.hpp"
 #include "VideoSource.hpp"
+#include "WorkerThread.hpp"
 #include <future>
 
 // Return true iff can write cl.outFile to work around VideoWriter.
@@ -89,12 +90,19 @@ static int batch(const CommandLine &cl)
             fps = cl.fps;
         }
         const cv::Size size = source.frameSize();
+
         cv::VideoWriter sink(cl.outFile, codec, fps, size);
 
         // Create 3 RieszTransforms. One for each section.
-        RieszTransform rt_left, rt_mid, rt_right;
-        cl.apply(rt_left); cl.apply(rt_mid); cl.apply(rt_right);
-        rt_left.fps(fps); rt_mid.fps(fps); rt_right.fps(fps);
+        static const int SPLIT = 3;
+        RieszTransform rt[SPLIT];
+        WorkerThread<cv::Mat, RieszTransform*, cv::Mat> thread[SPLIT];
+
+        for (int i = 0; i < SPLIT; i++) {
+            cl.apply(rt[i]);
+            rt[i].fps(fps);
+        }
+
         for (;;) {
             // for each frame
             cv::Mat frame; const bool more = source.read(frame);
@@ -108,21 +116,25 @@ static int batch(const CommandLine &cl)
             } else {
                 // Split a single 640 x 480 frame into equal sections, 1 section
                 // for each thread to process
-                const cv::Mat left = frame(cv::Range(0, frame.rows), cv::Range(0, frame.cols / 3));
-                const cv::Mat mid = frame(cv::Range(0, frame.rows), cv::Range(frame.cols / 3, frame.cols * 2 / 3));
-                const cv::Mat right = frame(cv::Range(0, frame.rows), cv::Range(frame.cols * 2 / 3, frame.cols));
-
                 // Run each transform independently.
-                auto t_left = std::async(std::launch::async, do_transforms, &rt_left, left);
-                auto t_mid = std::async(std::launch::async, do_transforms, &rt_mid, mid);
-                auto t_right = std::async(std::launch::async, do_transforms, &rt_right, right);
+
+                std::future<cv::Mat> futures[SPLIT];
+                cv::Mat in_sections[SPLIT];
+                cv::Mat out_sections[SPLIT];
+
+                for (int i = 0; i < SPLIT; i++) {
+                    auto rowRange = cv::Range(frame.rows * i / SPLIT, (i == SPLIT - 1) ? frame.rows : (frame.rows * (i+1) / 3));
+                    auto colRange = cv::Range(0, frame.cols);
+                    in_sections[i] = frame(rowRange, colRange);
+                    futures[i] = thread[i].push(do_transforms, &rt[i], in_sections[i]);
+                }
 
                 // recombine results and output
+                for (int i = 0; i < SPLIT; i++) {
+                    out_sections[i] = futures[i].get();
+                }
                 cv::Mat result;
-                cv::Mat sections[] = {
-                  t_left.get(), t_mid.get(), t_right.get(),
-                };
-                cv::hconcat(sections, 3, result);
+                cv::vconcat(out_sections, 3, result);
                 sink.write(result);
             }
         }


### PR DESCRIPTION
std::async spawns a new thread for every call, which is wasteful.
Instead, use a fixed size thread pool and push new items using a queue.

For practicality, the queue is just std::queue + std::mutex, instead
of something fancy like a lock-free queue or RCU. It is unlikely
there will be contention so it does not matter.

Closes #16 
