### PR TITLE
VideoSource: switch to native YUV/YCbCr

### DIFF
--- a/src/MotionDetection.cpp
+++ b/src/MotionDetection.cpp
@@ -272,7 +272,6 @@ void MotionDetection::pushFrameBuffer(cv::Mat newFrame) {
         frameBuffer[i] = frameBuffer[i + 1];
     }
     frameBuffer[MINIMUM_FRAMES-1] = newFrame;
-    cv::cvtColor(frameBuffer[MINIMUM_FRAMES-1], frameBuffer[MINIMUM_FRAMES-1], CV_BGR2GRAY);
 }
 
 void MotionDetection::reinitializeReisz(cv::Mat frame) {

--- a/src/RieszTransform.hpp
+++ b/src/RieszTransform.hpp
@@ -452,10 +452,8 @@ public:
     void initialize(const cv::Mat &frame) {
         static const double scaleFactor = 1.0 / 255.0;
         frame.convertTo(itsFrame, CV_32F, scaleFactor);
-        cv::cvtColor(itsFrame, itsFrame, cv::COLOR_RGB2YCrCb);
-        std::vector<cv::Mat> channels; cv::split(itsFrame, channels);
-        itsCurrent.initialize(channels[0]);
-        itsPrior.initialize(channels[0]);
+        itsCurrent.initialize(itsFrame);
+        itsPrior.initialize(itsFrame);
     }
 
     // Set the frames per second which is the filter sampling frequency.
@@ -481,21 +479,17 @@ public:
         static const double PI_PERCENT = M_PI / 100.0;
         static const double scaleFactor = 1.0 / 255.0;
         frame.convertTo(itsFrame, CV_32F, scaleFactor);
-        cv::cvtColor(itsFrame, itsFrame, cv::COLOR_RGB2YCrCb);
-        std::vector<cv::Mat> channels; cv::split(itsFrame, channels);
         cv::Mat result;
         if (itsCurrent) {
-            itsCurrent.build(channels[0]);
+            itsCurrent.build(itsFrame);
             itsCurrent.unwrapOrientPhase(itsPrior);
             itsBand.filterPyramids(itsCurrent, itsPrior);
             itsCurrent.amplify(itsAlpha, itsThreshold * PI_PERCENT);
-            channels[0] = itsCurrent.collapse();
-            cv::merge(channels, result);
-            cv::cvtColor(result, result, cv::COLOR_YCrCb2RGB);
-            result.convertTo(result, CV_8UC3, 255);
+            itsFrame = itsCurrent.collapse();
+            itsFrame.convertTo(result, CV_8UC1, 255);
         } else {
-            itsCurrent.initialize(channels[0]);
-            itsPrior.initialize(channels[0]);
+            itsCurrent.initialize(itsFrame);
+            itsPrior.initialize(itsFrame);
             frame.copyTo(result);
         }
         return std::move(result);

--- a/src/VideoSource.hpp
+++ b/src/VideoSource.hpp
@@ -68,6 +68,10 @@ public:
     VideoSource(const VideoSource&) = delete;
     VideoSource(VideoSource&&) = delete;
 
+    // Read the next frame into the provided matrix
+    // Only the Y channel is provided, and the result is a CV_8UC1 matrix
+    //
+    // Returns true if more frames are available in the input source, false when done
     bool read(cv::Mat& into);
 };
 


### PR DESCRIPTION
All our operations are in the Y channel (grayscale), so we don't
even need to read Cb/Cr from device memory, let alone spend precious
cycles converting to rgb (in hw), then to ycbcr (in sw),
then to rgb again (in sw) then to y again (in sw).

The tricky part is that YUV is a planar format, not a packed format.
That means that you get the Y component of all pixels, followed by
the Cb of all pixels, followed by the Cr of all pixels (as opposed
to R-G-B for each pixel). This is good for us, but also makes the
V4L2 API a little more annoying.